### PR TITLE
when a cache miss happens, set that cache value on the first layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ Provides a way to specify a single cache that is actually a hierarchy of underly
 
 - using an in-memory cache to support high throughput of cache operations within a request, while distributing the cached results for other workers to take advantage of
 - having a small, distributed, in-memory cache that holds the hottest items, while warmer items can be served out of a larger, local disk-based cache
+
+
+# Running tests
+
+```
+make test
+```
+
+NOTE: This will `pip install` requirements as well as run the tests in the example app.

--- a/layered_cache/backends/cache.py
+++ b/layered_cache/backends/cache.py
@@ -43,12 +43,13 @@ class LayeredCache(BaseCache):
 
         All configured cache levels will be checked in order, first to last.
         """
-        for level in self.levels:
+        for index, level in enumerate(self.levels):
             underlying_cache = self._get_underlying_cache(level)
             result = underlying_cache.get(key, version=version)
             if result is not None:
+                if index > 0:
+                    self._get_underlying_cache(self.levels[0]).set(key, result)
                 return result
-
         return default
 
     def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):

--- a/tests/testapp/tests/base_tests.py
+++ b/tests/testapp/tests/base_tests.py
@@ -39,6 +39,28 @@ def clear_caches(cache_names):
 
 class BaseLayeredCacheTestCase(TestCase):
     @clear_caches(SIMPLE_CACHES)
+    def test_get_after_miss_stores_in_first_layer(self):
+        """
+        Test that after a "miss" on the initial layer, a subsequent "hit" will
+        set the initial layer's cache value. This will make new cache requests
+        hit on the first layer instead of still going to the second.
+        """
+        coherent_cache = get_cache('simple_layered')
+        first_layer = get_cache('simple_in_mem')
+        second_layer = get_cache('simple_shared_mem')
+
+        second_layer.set("some_key_not_in_first_layer", 1)
+
+        self.assertEquals(coherent_cache.get("some_key_not_in_first_layer"), 1)
+
+        # Now we change the value in the second layer, the first layer should
+        # return 1
+        second_layer.set("some_key_not_in_first_layer", 2)
+
+        # Returning value from first layer now, second layer not hit!
+        self.assertEquals(coherent_cache.get("some_key_not_in_first_layer"), 1)
+
+    @clear_caches(SIMPLE_CACHES)
     def test_simple_set(self):
         """
         Simple test to make sure we can set/get.


### PR DESCRIPTION
## Changes

- Added some info to README for how to run tests
- When calling `cache.get(key)` and that key is a miss on the first layer, but found on another layer, set the first layer so responses are returned more quickly
- Adds test for above behavior

Let me know if you can think of some edge cases I may be missing in tests, thanks!
